### PR TITLE
fix: claim channel if claim is 0, remove profitability check

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -1077,6 +1077,7 @@ export default class XrpAccount {
       // so otherwise simply don't submit the claim
       const claim = spent.isGreaterThan(0)
         ? {
+            publicKey,
             signature: signature.toUpperCase(),
             balance: convert(drop(spent), xrp()).toFixed(
               6,
@@ -1093,7 +1094,6 @@ export default class XrpAccount {
         {
           channel: channelId,
           close: true,
-          publicKey,
           ...claim
         },
         {

--- a/src/account.ts
+++ b/src/account.ts
@@ -358,6 +358,7 @@ export default class XrpAccount {
       BigNumber.ROUND_DOWN
     )
 
+    await this.master._updateSequenceNumber()
     const {
       txJSON,
       instructions
@@ -370,7 +371,7 @@ export default class XrpAccount {
         publicKey: this.publicKey
       },
       {
-        sequence: this.master._sequenceNumber!++
+        sequence: this.master._sequenceNumber++
       }
     )
 
@@ -441,6 +442,7 @@ export default class XrpAccount {
         BigNumber.ROUND_DOWN
       )
 
+      await this.master._updateSequenceNumber()
       const {
         txJSON,
         instructions
@@ -451,7 +453,7 @@ export default class XrpAccount {
           amount: fundAmount
         },
         {
-          sequence: this.master._sequenceNumber!++
+          sequence: this.master._sequenceNumber++
         }
       )
 
@@ -1086,6 +1088,7 @@ export default class XrpAccount {
           }
         : {}
 
+      await this.master._updateSequenceNumber()
       const {
         txJSON,
         instructions
@@ -1097,7 +1100,7 @@ export default class XrpAccount {
           ...claim
         },
         {
-          sequence: this.master._sequenceNumber!++
+          sequence: this.master._sequenceNumber++
         }
       )
 

--- a/src/account.ts
+++ b/src/account.ts
@@ -1073,10 +1073,17 @@ export default class XrpAccount {
         return updatedChannel
       }
 
-      const balance = convert(drop(spent), xrp()).toFixed(
+      // Ripple-lib throws if the claim isn't positive,
+      // so otherwise simply don't submit the claim
+      const claim = spent.isGreaterThan(0)
+        ? {
+            signature: signature.toUpperCase(),
+            balance: convert(drop(spent), xrp()).toFixed(
         6,
         BigNumber.ROUND_DOWN
       )
+          }
+        : {}
 
       const {
         txJSON,
@@ -1085,10 +1092,9 @@ export default class XrpAccount {
         this.master._xrpAddress,
         {
           channel: channelId,
-          balance,
-          signature: signature.toUpperCase(),
+          close: true,
           publicKey,
-          close: true
+          ...claim
         },
         {
           sequence: this.master._sequenceNumber!++

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ export default class XrpPlugin extends EventEmitter2 implements PluginInstance {
   readonly _channelWatcherInterval: BigNumber // milliseconds
   readonly _store: StoreWrapper
   readonly _log: Logger
-  _sequenceNumber?: number
+  _sequenceNumber = 1
   _dataHandler: DataHandler = defaultDataHandler
   _moneyHandler: MoneyHandler = defaultMoneyHandler
 
@@ -252,11 +252,15 @@ export default class XrpPlugin extends EventEmitter2 implements PluginInstance {
     return this._accounts.get(accountName)!
   }
 
+  async _updateSequenceNumber() {
+    const { sequence } = await this._api.getAccountInfo(this._xrpAddress)
+    this._sequenceNumber = Math.max(this._sequenceNumber, sequence)
+  }
+
   async connect() {
     await this._api.connect()
 
-    const { sequence } = await this._api.getAccountInfo(this._xrpAddress)
-    this._sequenceNumber = sequence
+    await this._updateSequenceNumber()
 
     // Load all accounts from the store
     await this._store.loadObject('accounts')


### PR DESCRIPTION
*Breaking since it remains `claimIfProfitable` to `claimChannel` (since it no longer checks profitability)